### PR TITLE
Add group netaddress

### DIFF
--- a/lib/net/netaddress.js
+++ b/lib/net/netaddress.js
@@ -120,6 +120,42 @@ class NetAddress extends bio.Struct {
   }
 
   /**
+   * Test whether the address is RFC3964.
+   * @returns {Boolean}
+   */
+
+  isRFC3964() {
+    return IP.isRFC3964(this.raw);
+  }
+
+  /**
+   * Test whether the address is RFC4380.
+   * @returns {Boolean}
+   */
+
+  isRFC4380() {
+    return IP.isRFC4380(this.raw);
+  }
+
+  /**
+   * Test whether the address is RFC6052.
+   * @returns {Boolean}
+   */
+
+  isRFC6052() {
+    return IP.isRFC6052(this.raw);
+  }
+
+  /**
+   * Test whether the address is RFC6145.
+   * @returns {Boolean}
+   */
+
+  isRFC6145() {
+    return IP.isRFC6145(this.raw);
+  }
+
+  /**
    * Test whether the host is null.
    * @returns {Boolean}
    */
@@ -204,6 +240,74 @@ class NetAddress extends bio.Struct {
 
   getReachability(dest) {
     return IP.getReachability(this.raw, dest.raw);
+  }
+
+  /**
+ * Get the canonical identifier of our network group
+ * @returns {Buffer}
+ */
+
+  getGroup() {
+    const group = [];
+    let type = IP.networks.INET6;
+    let startByte = 0;
+    let bits = 16;
+
+    // all local addresses belong to the same group
+    if (this.isLocal()) {
+      type = 255;
+      bits = 16;
+    }
+
+    // all other unroutable addresses belong to the same group
+    if (!this.isRoutable()) {
+      type = IP.networks.NONE;
+      bits = 0;
+      // for IPv4 addresses, '1' + the 16 higher-order bits of the IP
+      // includes mapped IPv4, SIIT translated IPv4, and the well-known prefix
+    } else if (this.isIPv4() || this.isRFC6145() || this.isRFC6052()) {
+      type = IP.networks.INET4;
+      startByte = 12;
+      // for 6to4 tunnelled addresses, use the encapsulated IPv4 address
+    } else if (this.isRFC3964()) {
+      type = IP.networks.INET4;
+      startByte = 2;
+      // for Teredo-tunnelled IPv6 addresses, use the encapsulated IPv4 address
+    } else if (this.isRFC4380()) {
+      group.push(IP.networks.INET4);
+      group.push(this.raw[12] ^ 0xff);
+      group.push(this.raw[13] ^ 0xff);
+      return Buffer.from(group);
+    } else if (this.isOnion()) {
+      type = IP.networks.ONION;
+      startByte = 6;
+      bits = 4;
+      // for he.net, use /36 groups
+    } else if (
+      this.raw[0] === 0x20 &&
+      this.raw[1] === 0x01 &&
+      this.raw[2] === 0x04 &&
+      this.raw[3] === 0x70
+    ) {
+      bits = 36;
+       // for the rest of the IPv6 network, use /32 groups
+    } else {
+      bits = 32;
+    }
+
+    group.push(type);
+
+    while (bits >= 8) {
+      group.push(this.raw[startByte]);
+      startByte++;
+      bits -= 8;
+    }
+
+    if (bits > 0) {
+      group.push(this.raw[startByte] | ((1 << (8 - bits)) - 1));
+    }
+
+    return Buffer.from(group);
   }
 
   /**

--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -81,6 +81,7 @@ class Pool extends EventEmitter {
     this.nameMap = new BufferMap();
     this.pendingFilter = null;
     this.pendingRefill = null;
+    this.connectedGroups = new Set();
 
     this.checkpoints = false;
     this.headerChain = new List();
@@ -632,6 +633,10 @@ class Pool extends EventEmitter {
     if (!addr)
       return;
 
+    // Don't connect to outbound peers in the same group.
+    if (this.connectedGroups.has(addr.getGroup()))
+      return;
+
     if (!secp256k1.publicKeyVerify(addr.key)) {
       this.logger.info('Removing addr - invalid pubkey (%s).', addr.hostname);
       this.hosts.remove(addr.hostname);
@@ -643,6 +648,8 @@ class Pool extends EventEmitter {
     this.logger.info('Adding loader peer (%s).', peer.hostname());
 
     this.peers.add(peer);
+
+    this.connectedGroups.add(addr.getGroup());
 
     this.setLoader(peer);
   }
@@ -3331,9 +3338,15 @@ class Pool extends EventEmitter {
     if (!addr)
       return;
 
+    // Don't connect to outbound peers in the same group.
+    if (this.connectedGroups.has(addr.getGroup()))
+      return;
+
     const peer = this.createOutbound(addr);
 
     this.peers.add(peer);
+
+    this.connectedGroups.add(addr.getGroup());
 
     this.emit('peer', peer);
   }

--- a/test/netaddress.js
+++ b/test/netaddress.js
@@ -1,3 +1,12 @@
+/* Parts of this software are based on bitcoin/bitcoin:
+ *   Copyright (c) 2009-2019, The Bitcoin Core Developers (MIT License).
+ *   Copyright (c) 2009-2019, The Bitcoin Developers (MIT License).
+ *   https://github.com/bitcoin/bitcoin
+ *
+ * Resources:
+ *   https://github.com/bitcoin/bitcoin/blob/46fc4d1a24c88e797d6080336e3828e45e39c3fd/src/test/netbase_tests.cpp
+ */
+
 /* eslint-env mocha */
 /* eslint prefer-arrow-callback: "off" */
 

--- a/test/netaddress.js
+++ b/test/netaddress.js
@@ -1,0 +1,106 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const NetAddress = require('../lib/net/netaddress');
+
+describe('NetAddress', function() {
+  it('should return the correct group', () => {
+    // Local -> !Routable()
+    assert.bufferEqual(
+      NetAddress.fromHost('127.0.0.1', 13038, null, 'testnet').getGroup(),
+      Buffer.from([0])
+    );
+
+    // RFC1918 -> !Routable()
+    assert.bufferEqual(
+      NetAddress.fromHost('169.254.1.1', 13038, null, 'testnet').getGroup(),
+      Buffer.from([0])
+    );
+
+    // IPv4
+    assert.bufferEqual(
+      NetAddress.fromHost('1.2.3.4', 13038, null, 'testnet').getGroup(),
+      Buffer.from([1, 1, 2])
+    );
+
+    // RFC6145
+    assert.bufferEqual(
+      NetAddress.fromHost(
+        '::FFFF:0:102:304',
+        13038,
+        null,
+        'testnet'
+      ).getGroup(),
+      Buffer.from([1, 1, 2])
+    );
+
+    // RFC6052
+    assert.bufferEqual(
+      NetAddress.fromHost(
+        '64:FF9B::102:304',
+        13038,
+        null,
+        'testnet'
+      ).getGroup(),
+      Buffer.from([1, 1, 2])
+    );
+
+    // RFC3964
+    assert.bufferEqual(
+      NetAddress.fromHost(
+        '2002:102:304:9999:9999:9999:9999:9999',
+        13038,
+        null,
+        'testnet'
+      ).getGroup(),
+      Buffer.from([1, 1, 2])
+    );
+
+    // RFC4380
+    assert.bufferEqual(
+      NetAddress.fromHost(
+        '2001:0:9999:9999:9999:9999:FEFD:FCFB',
+        13038,
+        null,
+        'testnet'
+      ).getGroup(),
+      Buffer.from([1, 1, 2])
+    );
+
+    // Tor
+    assert.bufferEqual(
+      NetAddress.fromHost(
+        'FD87:D87E:EB43:edb1:8e4:3588:e546:35ca',
+        13038,
+        null,
+        'testnet'
+      ).getGroup(),
+      Buffer.from([3, 239])
+    );
+
+    // he.net
+    assert.bufferEqual(
+      NetAddress.fromHost(
+        '2001:470:abcd:9999:9999:9999:9999:9999',
+        13038,
+        null,
+        'testnet'
+      ).getGroup(),
+      Buffer.from([2, 32, 1, 4, 112, 175])
+    );
+
+    // IPv6
+    assert.bufferEqual(
+      NetAddress.fromHost(
+        '2001:2001:9999:9999:9999:9999:9999:9999',
+        13038,
+        null,
+        'testnet'
+      ).getGroup(),
+      Buffer.from([2, 32, 1, 32, 1])
+    );
+  });
+});


### PR DESCRIPTION
> This commit adds the getGroup function to net addresses. It allows for
network addresses to be grouped into buckets, such that we can limit the
number of outgoing connections per group to a certain amount. This will
allow for increased connection diversity and reduced attack surface
area.

TODO: 
- [x] RFC4380 not working.
- [x] Fix IPv6 test.
- [x] Use networks from Binet
- [x] comments
- [x] Add to outbound network connections to force them to be separate network groups. See: https://github.com/bitcoin/bitcoin/blob/0b68fca700713e8e4c843c982b6047dc04410bc0/src/net.cpp#L1769
- [x] ~~Add to hostlist~~ -Not backwards compatible, should go into a different PR, with other hostlist changes. 
- [x] License? Comments + Test cases are from bitcoin. 

See https://github.com/handshake-org/hsd/pull/217